### PR TITLE
Delete base PR template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,7 +1,0 @@
-#### Description:
-
-Explain what this PR does, what problem does it solve and what changes are being made to the code base.
-
-#### QA Notes (Optional):
-
-Add notes for QA to help with testing this PR.


### PR DESCRIPTION
Why? It only could be used properly by `-ui` and `-screen` projects, as backend projects do not need QA notes. We have 9 `-ui` and 9 `-screen` projects and 135 not related. This is especially unnecessary in our public projects.